### PR TITLE
BE: Remove Scores from "Property Search" endpoint response

### DIFF
--- a/app/controllers/api/v0/properties_controller.rb
+++ b/app/controllers/api/v0/properties_controller.rb
@@ -2,8 +2,8 @@ class Api::V0::PropertiesController < ApplicationController
   before_action :check_database_for_property, only: [:search]
 
   def search
-    PropertySearchFacade.new.set_scores(@property)
-    render json: PropertySerializer.new(@property)
+    PropertySearchFacade.new.set_city_and_state(@property)
+    render json: BasePropertySerializer.new(@property)
   end
 
   private

--- a/app/facades/property_search_facade.rb
+++ b/app/facades/property_search_facade.rb
@@ -15,6 +15,11 @@ class PropertySearchFacade
     property.safety_score = scores[:safety].to_s
   end
 
+  def set_city_and_state(property)
+    property.city = 'Philadelphia'
+    property.state = 'PA'
+  end
+
   private
 
   def normalize_search(street)
@@ -37,11 +42,6 @@ class PropertySearchFacade
     regex = Regexp.new(street_types.keys.map { |key| Regexp.escape(key) }.join('|'))
     normalized_text = text.gsub(regex, street_types)
     return number, normalized_text
-  end
-
-  def set_city_and_state(property)
-    property.city = 'Philadelphia'
-    property.state = 'PA'
   end
 
   def geocode(street)

--- a/spec/requests/api/v0/properties/search_request_spec.rb
+++ b/spec/requests/api/v0/properties/search_request_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Property Search Endpoint', :vcr do
     @property_2 = Property.create!(street: '1 CHRISTIAN ST', zip: '19147', license_number: '791507')
     @property_3 = Property.create!(street: '1 COTTON ST', zip: '19127', license_number: '725285')
   end
-  
+
   describe 'Property Search: Property Found in Database' do
     it 'returns data about a specific property if property search is successful' do
       street = '1 Brown Street'
@@ -36,7 +36,7 @@ RSpec.describe 'Property Search Endpoint', :vcr do
       expect(property[:attributes]).to be_a(Hash)
 
       attributes = property[:attributes]
-      keys = [:street, :city, :state, :zip, :walk_score, :transit_score, :bike_score, :safety_score]
+      keys = [:street, :city, :state, :zip]
       keys.each do |key|
         expect(attributes).to have_key(key)
         expect(attributes[key]).to be_a(String)


### PR DESCRIPTION
## Changes
- This PR closes #1 
- Updates Search Request Spec file tests to reflect expecting only property address data in JSON response for this endpoint, not scores
- Updates Property controller Search action to call the 'set city and state' method in the Search Facade, and use the Base Property serializer with fewer attributes
- Updates Property Search Facade to make the set city and state method public (it is still called inside the set scores method, when used to get full property details in Get A Property endpoint)

## Type of Changes
- [ ] new feature
- [ ] setup
- [ ] chore
- [ ] bug fix
- [x] refactor
- [ ] other: 

## Checklist
- [ ] Tests added for new functionality
- [x] All other tests are also passing (please note if not) 
  - Current coverage %: 99.5%, tests updated for refactored functionality

## Number of reviewers
- [x] 1
- [ ] 2
- [ ] 3

## Emoji or GIF about how you feel rn (optional)

