### PR TITLE
6 add nearby places to property details endpoint

### DIFF
--- a/app/facades/geocode_facade.rb
+++ b/app/facades/geocode_facade.rb
@@ -1,6 +1,10 @@
 class GeocodeFacade
   def get_coordinates(address)
-    format_data(coordinate_data(address))
+    format_coordinate_data(coordinate_data(address))
+  end
+
+  def get_parks(coordinates)
+    format_parks_data(parks_data(coordinates))
   end
 
   private
@@ -13,8 +17,26 @@ class GeocodeFacade
     @_coordinate_data ||= service.get_coordinates(address)
   end
 
-  def format_data(data)
+  def format_coordinate_data(data)
     { lat: data[:results][0][:position][:lat],
       lon: data[:results][0][:position][:lon] }
+  end
+
+  def parks_data(coordinates)
+    @_parks_data ||= service.get_parks(coordinates)
+  end
+
+  def format_parks_data(data)
+    parks = data[:results]
+    return {} if parks[0].nil? || parks[1].nil? || parks[2].nil?
+
+    {
+      park_1_name: parks[0][:poi][:name],
+      park_1_street: parks[0][:address][:freeformAddress],
+      park_2_name: parks[1][:poi][:name],
+      park_2_street: parks[1][:address][:freeformAddress],
+      park_3_name: parks[2][:poi][:name],
+      park_3_street: parks[2][:address][:freeformAddress]
+    }
   end
 end

--- a/app/facades/property_search_facade.rb
+++ b/app/facades/property_search_facade.rb
@@ -8,7 +8,7 @@ class PropertySearchFacade
     set_city_and_state(property)
     coordinates = geocode("#{property.street}, #{property.city}, #{property.state} #{property.zip}")
     threads = []
-    
+
     threads << Thread.new do
       property.lat = coordinates[:lat].to_s
       property.lon = coordinates[:lon].to_s
@@ -26,6 +26,10 @@ class PropertySearchFacade
       property.safety_score = safety_score[:safety].to_s
     end
 
+    threads << Thread.new do
+      parks = get_parks(coordinates)
+      property.parks = parks
+    end
 
     threads.each(&:join)
     property
@@ -70,5 +74,9 @@ class PropertySearchFacade
 
   def get_safety_score(coordinates)
     SafetyFacade.new.get_safety_score(coordinates[:lat], coordinates[:lon])
+  end
+
+  def get_parks(coordinates)
+    GeocodeFacade.new.get_parks(coordinates)
   end
 end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -1,4 +1,13 @@
 class Property < ApplicationRecord
-  attr_accessor :walk_score, :bike_score, :transit_score, :safety_score, :city, :state, :lat, :lon
+  attr_accessor :walk_score,
+                :bike_score,
+                :transit_score,
+                :safety_score,
+                :city,
+                :state,
+                :lat,
+                :lon,
+                :parks
+
   has_many :user_properties
 end

--- a/app/serializers/property_serializer.rb
+++ b/app/serializers/property_serializer.rb
@@ -3,5 +3,15 @@ class PropertySerializer
 
   set_type :property
   set_id :id
-  attributes :street, :city, :state, :zip, :walk_score, :bike_score, :transit_score, :safety_score, :lat, :lon
+  attributes :street,
+             :city,
+             :state,
+             :zip,
+             :walk_score,
+             :bike_score,
+             :transit_score,
+             :safety_score,
+             :lat,
+             :lon,
+             :parks
 end

--- a/app/services/geocode_service.rb
+++ b/app/services/geocode_service.rb
@@ -3,6 +3,10 @@ class GeocodeService
     get_url("/search/2/geocode/#{URI.encode_www_form_component(address)}.json")
   end
 
+  def get_parks(coordinates)
+    get_url("/search/2/categorySearch/parks.json?lat=#{coordinates[:lat]}&lon=#{coordinates[:lon]}&limit=3")
+  end
+
   private
 
   def get_url(url)

--- a/spec/facades/geocode_facade_spec.rb
+++ b/spec/facades/geocode_facade_spec.rb
@@ -13,5 +13,17 @@ RSpec.describe 'Geocode Facade', :vcr do
       expect(coordinates).to have_key(:lon)
       expect(coordinates[:lon]).to be_a(Float)
     end
+
+    it 'get_parks(coordinates)' do
+      coordinates = {lat: 39.92459089291047, lon: -75.16204921093596}
+      parks = GeocodeFacade.new.get_parks(coordinates)
+
+      expect(parks).to be_a(Hash)
+      keys = %i[park_1_name park_1_street park_2_name park_2_street park_3_name park_3_street]
+      keys.each do |key|
+        expect(parks).to have_key(key)
+        expect(parks[key]).to be_a(String)
+      end
+    end
   end
 end

--- a/spec/facades/property_search_facade_spec.rb
+++ b/spec/facades/property_search_facade_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'Property Search Facade', :vcr do
       expect(@property_1.safety_score).to be(nil)
       expect(@property_1.lat).to be(nil)
       expect(@property_1.lon).to be(nil)
+      expect(@property_1.parks).to be(nil)
 
       PropertySearchFacade.new.set_scores(@property_1)
 
@@ -36,6 +37,14 @@ RSpec.describe 'Property Search Facade', :vcr do
       expect(@property_1.safety_score).to be_a(String)
       expect(@property_1.lat).to be_a(String)
       expect(@property_1.lon).to be_a(String)
+      expect(@property_1.parks).to be_a(Hash)
+
+      parks = @property_1.parks
+      keys = %i[park_1_name park_1_street park_2_name park_2_street park_3_name park_3_street]
+      keys.each do |key|
+        expect(parks).to have_key(key)
+        expect(parks[key]).to be_a(String)
+      end
     end
   end
 end

--- a/spec/requests/api/v0/user_properties/show_spec.rb
+++ b/spec/requests/api/v0/user_properties/show_spec.rb
@@ -39,10 +39,20 @@ RSpec.describe 'Get one Property details for user' do
     attributes = user_property[:attributes]
     expect(attributes[:street]).to eq(@property_1.street)
 
-    keys = [:street, :city, :state, :zip, :walk_score, :transit_score, :bike_score, :safety_score, :lat, :lon]
+    keys = %i[street city state zip walk_score transit_score bike_score safety_score lat lon]
     keys.each do |key|
       expect(attributes).to have_key(key)
       expect(attributes[key]).to be_a(String)
+    end
+
+    expect(attributes).to have_key(:parks)
+    expect(attributes[:parks]).to be_a(Hash)
+
+    parks = attributes[:parks]
+    keys = %i[park_1_name park_1_street park_2_name park_2_street park_3_name park_3_street]
+    keys.each do |key|
+      expect(parks).to have_key(key)
+      expect(parks[key]).to be_a(String)
     end
   end
 end

--- a/spec/services/geocode_service_spec.rb
+++ b/spec/services/geocode_service_spec.rb
@@ -12,4 +12,13 @@ RSpec.describe GeocodeService do
     expect(coordinates[:lat]).to be_a(Float)
     expect(coordinates[:lon]).to be_a(Float)
   end
+
+  it 'returns data on 3 nearby parks', :vcr do
+    service = GeocodeService.new
+    result = service.get_parks({lat: 39.92459089291047, lon: -75.16204921093596})
+
+    expect(result).to be_a(Hash)
+    expect(result[:results]).to be_an(Array)
+    expect(result[:results].count).to eq(3)
+  end
 end


### PR DESCRIPTION
## Changes
- This PR closes #6 
- Adds workflow to consume TomTom Places - Search API and return 3 parks nearest to the target when given a lat / lon, including park name and address
-- Search is limited to 3 parks
-- If no parks are found, the facade handles sending an empty hash in the response
- Updates service, facade, and request spec files to reflect additional data in exposed REST endpoint

## Type of Changes
- [x] new feature
- [ ] setup
- [x] chore
- [ ] bug fix
- [ ] refactor
- [ ] other: 

## Checklist
- [x] Tests added for new functionality
- [x] All other tests are also passing (please note if not) 
  - Current coverage %:  99.5%

## Number of reviewers
- [x] 1
- [ ] 2
- [ ] 3

## Emoji or GIF about how you feel rn (optional)

